### PR TITLE
Modified the Root Token retrieval of hashicrop vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,18 @@ directory.
 
 ### Step 4: Start the Server
 
-1. Set the `VAULT_TOKEN` environment variable before starting the Identity Server.
+1. Provide the `VAULT_TOKEN` to the prompted message in the console or by creating a new file in the `<IS_HOME>` directory. 
+The file should be named according to your Operating System.
+
     ```
-    export VAULT_TOKEN='<token>'
+    For Linux   : The file name should be hashicorpRootToken-tmp.
+    For Windows : The file name should be hashicorpRootToken-tmp.txt.
+    ```
+    When you add "tmp" to the file name, note that this will automatically get deleted from the file system after server
+    starts. Alternatively, if you want to retain the password file after the server starts, the file should be named as follows:
+    ```
+    For Linux   : The file name should be hashicorpRootToken-persist.
+    For Windows : The file name should be hashicorpRootToken-persist.txt.
     ```
    
 2. Start the WSO2 Identity Server and enter the keystore password at the startup when prompted.

--- a/pom.xml
+++ b/pom.xml
@@ -30,10 +30,6 @@
                             org.apache.commons.lang;version="${commons-lang.wso2.osgi.version.range}",
                             org.apache.commons.logging;version="${commons-logging.osgi.version.range}",
 
-                            org.wso2.carbon.securevault.hashicorp.common;version="${org.wso2.carbon.securevault.import.version.range}",
-                            org.wso2.carbon.securevault.hashicorp.config;version="${org.wso2.carbon.securevault.import.version.range}",
-                            org.wso2.carbon.securevault.hashicorp.exception;version="${org.wso2.carbon.securevault.import.version.range}",
-
                             org.wso2.carbon.utils;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.securevault.keystore;version="${org.wso2.securevault.import.version.range}",
                             org.wso2.securevault.secret;version="${org.wso2.securevault.import.version.range}"
@@ -47,8 +43,6 @@
     <properties>
         <carbon.kernel.version>4.6.0</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
-
-        <org.wso2.carbon.securevault.import.version.range>[1.0.0, 2.0.0)</org.wso2.carbon.securevault.import.version.range>
 
         <import.package.version.commons.logging>[1.2.0,2.0.0)</import.package.version.commons.logging>
         <commons-lang.wso2.osgi.version.range>[2.6.0,3.0.0)</commons-lang.wso2.osgi.version.range>

--- a/src/main/java/org/wso2/carbon/securevault/hashicorp/common/HashiCorpVaultConstants.java
+++ b/src/main/java/org/wso2/carbon/securevault/hashicorp/common/HashiCorpVaultConstants.java
@@ -40,5 +40,5 @@ public class HashiCorpVaultConstants {
 
     public static final String VALUE_PARAMETER = "value";
 
-    public static final String TOKEN_PARAMETER = "VAULT_TOKEN";
+    public static final String CARBON_HOME = "carbon.home";
 }


### PR DESCRIPTION
## Purpose
>This is to make the HashiCorp Vault Connector retrieve the root token via a password configuration file or by prompting the user requesting the vault root token.

## Goals
> Root Token of the vault can be retrieved either by prompting the user via the console or by accessing the text file containing the root token.

## Approach
> **Retrieving Token**
> Root token can be given by creating a text file or via the console. when using the text file approach, users can keep the text file or discard it once it is done with reading. In order to achieve this, the file name will be used as the decision parameter.

## Marketing
> [External Vault Support for WSO2 Carbon Configurations - 4 | HashiCorp Vault ](https://medium.com/@sandunin/external-vault-support-for-wso2-carbon-configurations-4-hashicorp-vault-integration-739a2fb95574)

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> JDK version - 1.8
> Operating System - Ubuntu 18.04