### PR TITLE
Remove logger import

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,6 @@
                             com.bettercloud.vault.response,
 
                             org.apache.commons.lang;version="${commons-lang.wso2.osgi.version.range}",
-                            org.apache.commons.logging;version="${commons-logging.osgi.version.range}",
 
                             org.wso2.carbon.utils;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.securevault.keystore;version="${org.wso2.securevault.import.version.range}",
@@ -72,7 +71,6 @@
 
         <import.package.version.commons.logging>[1.2.0,2.0.0)</import.package.version.commons.logging>
         <commons-lang.wso2.osgi.version.range>[2.6.0,3.0.0)</commons-lang.wso2.osgi.version.range>
-        <commons-logging.osgi.version.range>[1.2.0,2.0.0)</commons-logging.osgi.version.range>
 
         <com.bettercloud.vault.version>5.1.0</com.bettercloud.vault.version>
         <com.bettercloud.vault.import.version.range>[5.1.0, 6.0.0)</com.bettercloud.vault.import.version.range>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
                             com.bettercloud.vault.response,
 
                             org.apache.commons.lang;version="${commons-lang.wso2.osgi.version.range}",
+                            org.apache.commons.logging;version="${commons-logging.osgi.version.range}",
 
                             org.wso2.carbon.utils;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.securevault.keystore;version="${org.wso2.securevault.import.version.range}",

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,6 @@
                             com.bettercloud.vault.response,
 
                             org.apache.commons.lang;version="${commons-lang.wso2.osgi.version.range}",
-                            org.apache.commons.logging;version="${commons-logging.osgi.version.range}",
 
                             org.wso2.carbon.utils;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.securevault.keystore;version="${org.wso2.securevault.import.version.range}",

--- a/src/main/java/org/wso2/carbon/securevault/hashicorp/repository/HashiCorpSecretRepository.java
+++ b/src/main/java/org/wso2/carbon/securevault/hashicorp/repository/HashiCorpSecretRepository.java
@@ -101,8 +101,6 @@ public class HashiCorpSecretRepository implements SecretRepository {
     @Override
     public void init(Properties properties, String id) {
 
-        LOG.info("Initializing HashiCorp Secure Vault");
-
         // Load Configurations
         HashiCorpVaultConfigLoader hashiCorpVaultConfigLoader = HashiCorpVaultConfigLoader.getInstance();
         try {

--- a/src/main/java/org/wso2/carbon/securevault/hashicorp/repository/HashiCorpSecretRepository.java
+++ b/src/main/java/org/wso2/carbon/securevault/hashicorp/repository/HashiCorpSecretRepository.java
@@ -101,6 +101,8 @@ public class HashiCorpSecretRepository implements SecretRepository {
     @Override
     public void init(Properties properties, String id) {
 
+        LOG.info("Initializing HashiCorp Secure Vault");
+
         // Load Configurations
         HashiCorpVaultConfigLoader hashiCorpVaultConfigLoader = HashiCorpVaultConfigLoader.getInstance();
         try {


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/api-manager/issues/4394

## Approach 
Remove OSGI import
`org.wso2.carbon.utils.logging; version="4.9.27"[exported]` exported in `org.wso2.carbon.utils_4.9.27.11`. therefore this import is not required